### PR TITLE
chg: removing import from theme library for Vuex datastore

### DIFF
--- a/js/ucb-incident-app.js
+++ b/js/ucb-incident-app.js
@@ -1,6 +1,6 @@
 // Vue.JS code to deal with the dynamic loading of updated events for Incidents
 
-// import store from './store';
+import store from './store.js';
 
 Vue.component('ucb-incident-event', {
     props: {

--- a/ucb2019_base.libraries.yml
+++ b/ucb2019_base.libraries.yml
@@ -82,5 +82,5 @@ ucb-incident-page:
     js/Vue/vuex.js: {}
     js/lib/moment.min.js: {}
     js/ucb-incident.js: {}
-    js/store.js: { attributes: { type: "module" } }
+#    js/store.js: { attributes: { type: "module" } }
     js/ucb-incident-app.js: { attributes: { type: "module" } }


### PR DESCRIPTION
chg: removing import from theme library for Vuex datastore and loading only from the Vue app import definition.  