### PR TITLE
Removing a hard-coded development URL

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -57,7 +57,7 @@ const store = new Vuex.Store({
       }
 
       if(DEBUG) {
-        console.log("store.js : Loading data from : " + payload)
+        console.log("store.js : Loading Media Image data from : " + payload)
       }
 
       axios.get(payload)
@@ -84,16 +84,22 @@ const store = new Vuex.Store({
         })
     },
     ADD_INCIDENT_EVENT_DATA : (state, payload) => {
-      // given the payload (uid), load the data for that Incident Event and store the data
-      const dataURL = "/alerts/web/jsonapi/paragraph/ucb_incident_update/" +
-        encodeURI(payload) +
-        "?include=field_ucb_incident_images,field_ucb_incident_images.field_media_image"
 
-      if(DEBUG) {
-        console.log("Loading data from : " + dataURL)
+      if(!payload.includes('/jsonapi/paragraph/ucb_incident_update')) {
+        console.log('store.js : Likely invalid URL for image load : ' + payload)
+        return;
       }
 
-      axios.get(dataURL)
+      if(DEBUG) {
+        console.log("store.js : Loading Incident Event Data from : " + payload)
+      }
+
+      // given the payload (uid), load the data for that Incident Event and store the data
+      //const dataURL = "/alerts/web/jsonapi/paragraph/ucb_incident_update/" +
+        //encodeURI(payload) +
+        //"?include=field_ucb_incident_images,field_ucb_incident_images.field_media_image"
+
+      axios.get(payload)
         .then(function (response) {
           let jsonData = JSON.stringify(response.data.data)
           let jsonObject = {}

--- a/js/ucb-incident-app.js
+++ b/js/ucb-incident-app.js
@@ -264,7 +264,8 @@ Vue.component('ucb-incident-event', {
           store.dispatch("addIncidentEventId", IncidentEventsData[event].id);
 
           // get the JSON data for that event and save it
-          store.dispatch("addIncidentEventData", IncidentEventsData[event].id);
+          const eventJsonDataUrl = `${this.fronturl}/jsonapi/paragraph/ucb_incident_update/${IncidentEventsData[event].id}?include=field_ucb_incident_images,field_ucb_incident_images.field_media_image`;
+          store.dispatch("addIncidentEventData", eventJsonDataUrl);
         }
       })
       .catch(error => {


### PR DESCRIPTION
chg: removing hard-coded URL that worked on development box and replacing with a variable that should work anywhere for the Vuex datastore.  !bug